### PR TITLE
renamed ec2 to droplet to prevent conflicts

### DIFF
--- a/charts/droplet-operator/templates/rbac.yaml
+++ b/charts/droplet-operator/templates/rbac.yaml
@@ -96,7 +96,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: ec2-leader-election-rolebinding
+  name: droplet-operator-leader-election-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -109,7 +109,7 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: ec2-resources-cluster-rolebinding
+  name: droplet-operator-resources-cluster-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole


### PR DESCRIPTION
This conflict prevents installation of the two helm charts into the same cluster. 
Renaming ec2- to droplet-operator- should resolve this. 